### PR TITLE
App package from 'softwaregroup.com' to 'com.softwaregroup'

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/UnderTheKotlinTree.iml" filepath="$PROJECT_DIR$/UnderTheKotlinTree.iml" />
+      <module fileurl="file://$PROJECT_DIR$/UnderTheKotlinTree.iml" filepath="$PROJECT_DIR$/UnderTheKotlinTree.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 26
     defaultConfig {
-        applicationId "softwaregroup.com.underthekotlintree"
+        applicationId "com.softwaregroup.underthekotlintree"
         minSdkVersion 19
         targetSdkVersion 26
         versionCode 1

--- a/app/src/androidTest/java/com/softwaregroup/underthekotlintree/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/softwaregroup/underthekotlintree/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package softwaregroup.com.underthekotlintree
+package com.softwaregroup.underthekotlintree
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getTargetContext()
-        assertEquals("softwaregroup.com.underthekotlintree", appContext.packageName)
+        assertEquals("com.softwaregroup.underthekotlintree", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="softwaregroup.com.underthekotlintree">
+    package="com.softwaregroup.underthekotlintree">
 
     <application
         android:allowBackup="true"
@@ -9,16 +9,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
         <activity
             android:name=".ui.MainActivity"
-            android:label="@string/title_activity_main"
+            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/softwaregroup/underthekotlintree/ui/MainActivity.kt
+++ b/app/src/main/java/com/softwaregroup/underthekotlintree/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package softwaregroup.com.underthekotlintree.ui
+package com.softwaregroup.underthekotlintree.ui
 
 import android.os.Bundle
 import android.support.design.widget.Snackbar
@@ -10,7 +10,7 @@ import android.view.Menu
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
-import softwaregroup.com.underthekotlintree.R
+import com.softwaregroup.underthekotlintree.R
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
 

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="softwaregroup.com.underthekotlintree.ui.MainActivity">
+    tools:context="com.softwaregroup.underthekotlintree.ui.MainActivity">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context="softwaregroup.com.underthekotlintree.ui.MainActivity"
+    tools:context="com.softwaregroup.underthekotlintree.ui.MainActivity"
     tools:showIn="@layout/app_bar_main">
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/test/java/com/softwaregroup/underthekotlintree/ExampleUnitTest.kt
+++ b/app/src/test/java/com/softwaregroup/underthekotlintree/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package softwaregroup.com.underthekotlintree
+package com.softwaregroup.underthekotlintree
 
 import org.junit.Test
 


### PR DESCRIPTION
Had manually inverted the SLD and TLD during project creation. AndroidStudio, expecting astandard domain, then flipped it back. Renamed it to correct inverted form "com.softwaregroup.underthekotlintree" in all imports, dirs and app id.